### PR TITLE
Fix overdueCourses typo

### DIFF
--- a/AceClass/AppState.swift
+++ b/AceClass/AppState.swift
@@ -531,7 +531,7 @@ class AppState: ObservableObject {
     }
     
     /// 獲取所有過期的課程
-    var overdueCoures: [Course] {
+    var overdueCourses: [Course] {
         return courses.filter { $0.isOverdue }.sorted { course1, course2 in
             let days1 = abs(course1.daysRemaining ?? 0)
             let days2 = abs(course2.daysRemaining ?? 0)

--- a/AceClass/CountdownOverviewView.swift
+++ b/AceClass/CountdownOverviewView.swift
@@ -13,7 +13,7 @@ struct CountdownOverviewView: View {
                     }
                     
                     // 已過期的課程
-                    if !appState.overdueCoures.isEmpty {
+                    if !appState.overdueCourses.isEmpty {
                         overdueCoursesSection
                     }
                     
@@ -51,12 +51,12 @@ struct CountdownOverviewView: View {
         VStack(alignment: .leading, spacing: 12) {
             SectionHeader(
                 title: "已過期",
-                subtitle: "\(appState.overdueCoures.count) 個課程",
+                  subtitle: "\(appState.overdueCourses.count) 個課程",
                 icon: "exclamationmark.triangle.fill",
                 color: .red
             )
             
-            ForEach(appState.overdueCoures, id: \.id) { course in
+              ForEach(appState.overdueCourses, id: \.id) { course in
                 CourseCountdownCard(course: course, appState: appState)
             }
         }

--- a/AceClass/CountdownSettingsView.swift
+++ b/AceClass/CountdownSettingsView.swift
@@ -30,7 +30,7 @@ struct CountdownSettingsView: View {
                     .cornerRadius(12)
                     
                     // 課程狀態概覽
-                    if !appState.upcomingDeadlines.isEmpty || !appState.overdueCoures.isEmpty {
+                    if !appState.upcomingDeadlines.isEmpty || !appState.overdueCourses.isEmpty {
                         courseStatusSection
                             .padding()
                             .background(Color(.controlBackgroundColor))
@@ -182,7 +182,7 @@ struct CountdownSettingsView: View {
                 .font(.headline)
             
             let upcomingDeadlines = appState.upcomingDeadlines
-            let overdueCoures = appState.overdueCoures
+            let overdueCourses = appState.overdueCourses
             
             if !upcomingDeadlines.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
@@ -211,7 +211,7 @@ struct CountdownSettingsView: View {
                 }
             }
             
-            if !overdueCoures.isEmpty {
+            if !overdueCourses.isEmpty {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
                         Image(systemName: "exclamationmark.triangle.fill")
@@ -222,7 +222,7 @@ struct CountdownSettingsView: View {
                             .foregroundColor(.red)
                     }
                     
-                    ForEach(overdueCoures, id: \.id) { course in
+                    ForEach(overdueCourses, id: \.id) { course in
                         HStack {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(course.folderURL.lastPathComponent)
@@ -238,7 +238,7 @@ struct CountdownSettingsView: View {
                 }
             }
             
-            if upcomingDeadlines.isEmpty && overdueCoures.isEmpty {
+            if upcomingDeadlines.isEmpty && overdueCourses.isEmpty {
                 Text("目前沒有即將到期或過期的課程")
                     .foregroundColor(.secondary)
                     .italic()

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -451,7 +451,7 @@ struct CountdownSettingsView: View {
                     .cornerRadius(12)
                 
                     // 課程狀態概覽
-                    if !appState.upcomingDeadlines.isEmpty || !appState.overdueCoures.isEmpty {
+                    if !appState.upcomingDeadlines.isEmpty || !appState.overdueCourses.isEmpty {
                         courseStatusSection
                             .padding()
                             .background(Color(.controlBackgroundColor))


### PR DESCRIPTION
## Summary
- rename `overdueCoures` to `overdueCourses`
- update property usage in overview and settings views
- fix documentation referencing the old property name

## Testing
- `swiftc -parse AceClass/AppState.swift AceClass/AceClassApp.swift`
- `find AceClass -name '*.swift' | xargs swiftc -parse`

------
https://chatgpt.com/codex/tasks/task_e_686c9305bfa4832fbff62bda2057c749