### PR TITLE
Fix README typos and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AceClass
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ ls -la ~/Library/Containers/$YourUserName$.AceClass/
 
 - **GitHub Issues**: [在此回報問題](https://github.com/your-repo/AceClass/issues)
 - **電子郵件**: support@aceclass.app
-- **文檔**: 查看完整的開發文檔 `DEVELOPMENT.md`
+- **文檔**: 查看完整的開發文檔 `DEVELOPER_GUIDE.md`
 
 #### 隱私聲明
 
@@ -446,7 +446,7 @@ ls -la ~/Library/Containers/$YourUserName$.AceClass/
 - **倒數計日概覽**：統一查看所有課程的目標狀態和學習進度
 - **目標描述功能**：為每個目標添加詳細說明（如：期末考試、作業截止等）
 
-#### � 介面改進
+#### 💻 介面改進
 - **CountdownSettingsView**：專用的倒數計日設定界面
   - Toggle 開關控制目標日期啟用/停用
   - DatePicker 選擇目標日期
@@ -479,7 +479,7 @@ ls -la ~/Library/Containers/$YourUserName$.AceClass/
 - **CountdownStatus 枚舉**：定義四種倒數計日狀態
 - **AppState 方法擴展**：新增倒數計日資料的 CRUD 操作方法
 
-#### � 隱私與安全
+#### 🔒 隱私與安全
 - **本地優先**：倒數計日設定僅存本地，保護個人學習計劃隱私
 - **沙盒相容**：完全符合 macOS App Sandbox 安全要求
 - **資料隔離**：不同課程的設定完全獨立，避免資料衝突


### PR DESCRIPTION
## Summary
- update README link to `DEVELOPER_GUIDE.md`
- repair two garbled headings
- add missing MIT `LICENSE`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9306a218832fa6dc78ba11ef6300